### PR TITLE
refactor: replace deprecated io/ioutil with io and os

### DIFF
--- a/install_test.go
+++ b/install_test.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -13,7 +12,7 @@ import (
 )
 
 func TestBootstrap(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/run.go
+++ b/internal/run.go
@@ -3,7 +3,7 @@ package internal
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"os/exec"
@@ -11,7 +11,7 @@ import (
 	"strings"
 )
 
-var debug *log.Logger = log.New(ioutil.Discard, "", 0)
+var debug = log.New(io.Discard, "", 0)
 
 func SetDebug(l *log.Logger) {
 	debug = l

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -7,7 +7,7 @@ import (
 	"go/doc"
 	"go/parser"
 	"go/token"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"sort"
@@ -19,7 +19,7 @@ import (
 
 const importTag = "stave:import"
 
-var debug = log.New(ioutil.Discard, "DEBUG: ", log.Ltime|log.Lmicroseconds)
+var debug = log.New(io.Discard, "DEBUG: ", log.Ltime|log.Lmicroseconds)
 
 // EnableDebug turns on debug logging.
 func EnableDebug() {

--- a/sh/helpers_test.go
+++ b/sh/helpers_test.go
@@ -3,7 +3,6 @@ package sh_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -29,11 +28,11 @@ func compareFiles(file1 string, file2 string) error {
 	if s1.Mode() != s2.Mode() {
 		return fmt.Errorf("files %s and %s have different permissions: %#4o vs %#4o", file1, file2, s1.Mode(), s2.Mode())
 	}
-	f1bytes, err := ioutil.ReadFile(file1)
+	f1bytes, err := os.ReadFile(file1)
 	if err != nil {
 		return fmt.Errorf("can't read %s: %v", file1, err)
 	}
-	f2bytes, err := ioutil.ReadFile(file2)
+	f2bytes, err := os.ReadFile(file2)
 	if err != nil {
 		return fmt.Errorf("can't read %s: %v", file2, err)
 	}
@@ -45,7 +44,7 @@ func compareFiles(file1 string, file2 string) error {
 
 func TestHelpers(t *testing.T) {
 
-	mytmpdir, err := ioutil.TempDir("", "stave")
+	mytmpdir, err := os.MkdirTemp("", "stave")
 	if err != nil {
 		t.Fatalf("can't create test directory: %v", err)
 	}
@@ -56,7 +55,7 @@ func TestHelpers(t *testing.T) {
 		}
 	}()
 	srcname := filepath.Join(mytmpdir, "test1.txt")
-	err = ioutil.WriteFile(srcname, []byte("All work and no play makes Jack a dull boy."), 0644)
+	err = os.WriteFile(srcname, []byte("All work and no play makes Jack a dull boy."), 0644)
 	if err != nil {
 		t.Fatalf("can't create test file %s: %v", srcname, err)
 	}

--- a/stave/main.go
+++ b/stave/main.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"go/build"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -67,7 +66,7 @@ const (
 	initFile = "stavefile.go"
 )
 
-var debug = log.New(ioutil.Discard, "DEBUG: ", log.Ltime|log.Lmicroseconds)
+var debug = log.New(io.Discard, "DEBUG: ", log.Ltime|log.Lmicroseconds)
 
 // set by ldflags when you "stave build"
 var (
@@ -759,18 +758,18 @@ func filter(list []string, prefix string) []string {
 // directory.
 func removeContents(dir string) error {
 	debug.Println("removing all files in", dir)
-	files, err := ioutil.ReadDir(dir)
+	entries, err := os.ReadDir(dir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil
 		}
 		return err
 	}
-	for _, f := range files {
-		if f.IsDir() {
+	for _, entry := range entries {
+		if entry.IsDir() {
 			continue
 		}
-		err = os.Remove(filepath.Join(dir, f.Name()))
+		err = os.Remove(filepath.Join(dir, entry.Name()))
 		if err != nil {
 			return err
 		}

--- a/stave/main_test.go
+++ b/stave/main_test.go
@@ -12,7 +12,6 @@ import (
 	"go/parser"
 	"go/token"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -43,7 +42,7 @@ func TestMain(m *testing.M) {
 func testmain(m *testing.M) int {
 	// ensure we write our temporary binaries to a directory that we'll delete
 	// after running tests.
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -251,7 +250,7 @@ func TestListStavefilesIgnoresRespectsGOOSArg(t *testing.T) {
 }
 
 func TestCompileDiffGoosGoarch(t *testing.T) {
-	target, err := ioutil.TempDir("./testdata", "")
+	target, err := os.MkdirTemp("./testdata", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -552,7 +551,7 @@ func TestVerboseEnv(t *testing.T) {
 	os.Setenv("MAGEFILE_VERBOSE", "true")
 	defer os.Unsetenv("MAGEFILE_VERBOSE")
 	stdout := &bytes.Buffer{}
-	inv, _, err := Parse(ioutil.Discard, stdout, []string{})
+	inv, _, err := Parse(io.Discard, stdout, []string{})
 	if err != nil {
 		t.Fatal("unexpected error", err)
 	}
@@ -568,7 +567,7 @@ func TestVerboseFalseEnv(t *testing.T) {
 	os.Setenv("MAGEFILE_VERBOSE", "0")
 	defer os.Unsetenv("MAGEFILE_VERBOSE")
 	stdout := &bytes.Buffer{}
-	code := ParseAndRun(ioutil.Discard, stdout, nil, []string{"-d", "testdata", "testverbose"})
+	code := ParseAndRun(io.Discard, stdout, nil, []string{"-d", "testdata", "testverbose"})
 	if code != 0 {
 		t.Fatal("unexpected code", code)
 	}
@@ -583,7 +582,7 @@ func TestList(t *testing.T) {
 	inv := Invocation{
 		Dir:    "./testdata/list",
 		Stdout: stdout,
-		Stderr: ioutil.Discard,
+		Stderr: io.Discard,
 		List:   true,
 	}
 
@@ -658,7 +657,7 @@ Targets:
 			inv := Invocation{
 				Dir:    "./testdata/list",
 				Stdout: stdout,
-				Stderr: ioutil.Discard,
+				Stderr: io.Discard,
 				List:   true,
 			}
 
@@ -750,7 +749,7 @@ func TestTargetError(t *testing.T) {
 	stderr := &bytes.Buffer{}
 	inv := Invocation{
 		Dir:    "./testdata",
-		Stdout: ioutil.Discard,
+		Stdout: io.Discard,
 		Stderr: stderr,
 		Args:   []string{"returnsnonnilerror"},
 	}
@@ -770,7 +769,7 @@ func TestStdinCopy(t *testing.T) {
 	stdin := strings.NewReader("hi!")
 	inv := Invocation{
 		Dir:    "./testdata",
-		Stderr: ioutil.Discard,
+		Stderr: io.Discard,
 		Stdout: stdout,
 		Stdin:  stdin,
 		Args:   []string{"CopyStdin"},
@@ -790,7 +789,7 @@ func TestTargetPanics(t *testing.T) {
 	stderr := &bytes.Buffer{}
 	inv := Invocation{
 		Dir:    "./testdata",
-		Stdout: ioutil.Discard,
+		Stdout: io.Discard,
 		Stderr: stderr,
 		Args:   []string{"panics"},
 	}
@@ -809,7 +808,7 @@ func TestPanicsErr(t *testing.T) {
 	stderr := &bytes.Buffer{}
 	inv := Invocation{
 		Dir:    "./testdata",
-		Stdout: ioutil.Discard,
+		Stdout: io.Discard,
 		Stderr: stderr,
 		Args:   []string{"panicserr"},
 	}
@@ -1002,7 +1001,7 @@ func TestBadSecondTargets(t *testing.T) {
 
 func TestParse(t *testing.T) {
 	buf := &bytes.Buffer{}
-	inv, cmd, err := Parse(ioutil.Discard, buf, []string{"-v", "-debug", "-gocmd=foo", "-d", "dir", "build", "deploy"})
+	inv, cmd, err := Parse(io.Discard, buf, []string{"-v", "-debug", "-gocmd=foo", "-d", "dir", "build", "deploy"})
 	if err != nil {
 		t.Fatal("unexpected error", err)
 	}
@@ -1097,12 +1096,12 @@ func TestTimeout(t *testing.T) {
 
 func TestParseHelp(t *testing.T) {
 	buf := &bytes.Buffer{}
-	_, _, err := Parse(ioutil.Discard, buf, []string{"-h"})
+	_, _, err := Parse(io.Discard, buf, []string{"-h"})
 	if err != flag.ErrHelp {
 		t.Fatal("unexpected error", err)
 	}
 	buf2 := &bytes.Buffer{}
-	_, _, err = Parse(ioutil.Discard, buf2, []string{"--help"})
+	_, _, err = Parse(io.Discard, buf2, []string{"--help"})
 	if err != flag.ErrHelp {
 		t.Fatal("unexpected error", err)
 	}
@@ -1118,7 +1117,7 @@ func TestHelpTarget(t *testing.T) {
 	inv := Invocation{
 		Dir:    "./testdata",
 		Stdout: stdout,
-		Stderr: ioutil.Discard,
+		Stderr: io.Discard,
 		Args:   []string{"panics"},
 		Help:   true,
 	}
@@ -1138,7 +1137,7 @@ func TestHelpAlias(t *testing.T) {
 	inv := Invocation{
 		Dir:    "./testdata/alias",
 		Stdout: stdout,
-		Stderr: ioutil.Discard,
+		Stderr: io.Discard,
 		Args:   []string{"status"},
 		Help:   true,
 	}
@@ -1154,7 +1153,7 @@ func TestHelpAlias(t *testing.T) {
 	inv = Invocation{
 		Dir:    "./testdata/alias",
 		Stdout: stdout,
-		Stderr: ioutil.Discard,
+		Stderr: io.Discard,
 		Args:   []string{"checkout"},
 		Help:   true,
 	}
@@ -1177,7 +1176,7 @@ func TestAlias(t *testing.T) {
 	inv := Invocation{
 		Dir:    "testdata/alias",
 		Stdout: stdout,
-		Stderr: ioutil.Discard,
+		Stderr: io.Discard,
 		Args:   []string{"status"},
 		Debug:  true,
 	}
@@ -1204,10 +1203,10 @@ func TestAlias(t *testing.T) {
 
 func TestInvalidAlias(t *testing.T) {
 	stderr := &bytes.Buffer{}
-	log.SetOutput(ioutil.Discard)
+	log.SetOutput(io.Discard)
 	inv := Invocation{
 		Dir:    "./testdata/invalid_alias",
-		Stdout: ioutil.Discard,
+		Stdout: io.Discard,
 		Stderr: stderr,
 		Args:   []string{"co"},
 	}
@@ -1239,7 +1238,7 @@ func TestCompiledFlags(t *testing.T) {
 	stderr := &bytes.Buffer{}
 	stdout := &bytes.Buffer{}
 	dir := "./testdata/compiled"
-	compileDir, err := ioutil.TempDir(dir, "")
+	compileDir, err := os.MkdirTemp(dir, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1326,7 +1325,7 @@ func TestCompiledEnvironmentVars(t *testing.T) {
 	stderr := &bytes.Buffer{}
 	stdout := &bytes.Buffer{}
 	dir := "./testdata/compiled"
-	compileDir, err := ioutil.TempDir(dir, "")
+	compileDir, err := os.MkdirTemp(dir, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1418,7 +1417,7 @@ func TestCompiledVerboseFlag(t *testing.T) {
 	stderr := &bytes.Buffer{}
 	stdout := &bytes.Buffer{}
 	dir := "./testdata/compiled"
-	compileDir, err := ioutil.TempDir(dir, "")
+	compileDir, err := os.MkdirTemp(dir, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1484,7 +1483,7 @@ func TestSignals(t *testing.T) {
 	stderr := &bytes.Buffer{}
 	stdout := &bytes.Buffer{}
 	dir := "./testdata/signals"
-	compileDir, err := ioutil.TempDir(dir, "")
+	compileDir, err := os.MkdirTemp(dir, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1587,7 +1586,7 @@ func TestSignals(t *testing.T) {
 
 func TestCompiledDeterministic(t *testing.T) {
 	dir := "./testdata/compiled"
-	compileDir, err := ioutil.TempDir(dir, "")
+	compileDir, err := os.MkdirTemp(dir, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1653,13 +1652,13 @@ func TestClean(t *testing.T) {
 	if err := os.RemoveAll(mg.CacheDir()); err != nil {
 		t.Error("error removing cache dir:", err)
 	}
-	code := ParseAndRun(ioutil.Discard, ioutil.Discard, &bytes.Buffer{}, []string{"-clean"})
+	code := ParseAndRun(io.Discard, io.Discard, &bytes.Buffer{}, []string{"-clean"})
 	if code != 0 {
 		t.Errorf("expected 0, but got %v", code)
 	}
 
 	TestAlias(t) // make sure we've got something in the CACHE_DIR
-	files, err := ioutil.ReadDir(mg.CacheDir())
+	files, err := os.ReadDir(mg.CacheDir())
 	if err != nil {
 		t.Error("issue reading file:", err)
 	}
@@ -1668,7 +1667,7 @@ func TestClean(t *testing.T) {
 		t.Error("Need at least 1 cached binaries to test --clean")
 	}
 
-	_, cmd, err := Parse(ioutil.Discard, ioutil.Discard, []string{"-clean"})
+	_, cmd, err := Parse(io.Discard, io.Discard, []string{"-clean"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1676,12 +1675,12 @@ func TestClean(t *testing.T) {
 		t.Errorf("Expected 'clean' command but got %v", cmd)
 	}
 	buf := &bytes.Buffer{}
-	code = ParseAndRun(ioutil.Discard, buf, &bytes.Buffer{}, []string{"-clean"})
+	code = ParseAndRun(io.Discard, buf, &bytes.Buffer{}, []string{"-clean"})
 	if code != 0 {
 		t.Fatalf("expected 0, but got %v: %s", code, buf)
 	}
 
-	infos, err := ioutil.ReadDir(mg.CacheDir())
+	infos, err := os.ReadDir(mg.CacheDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1706,7 +1705,7 @@ func TestGoCmd(t *testing.T) {
 	}
 
 	// fake out the compiled file, since the code checks for it.
-	f, err := ioutil.TempFile("", "")
+	f, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1734,13 +1733,13 @@ func TestGoModules(t *testing.T) {
 	if len(matches) < 2 || minorVer(t, matches[1]) < 11 {
 		t.Skipf("Skipping Go modules test because go version %q is less than go1.11", runtime.Version())
 	}
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(dir)
 	// beware, staff builds in go versions older than 1.17 so both build tag formats need to be present
-	err = ioutil.WriteFile(filepath.Join(dir, "stavefile.go"), []byte(`//go:build stave
+	err = os.WriteFile(filepath.Join(dir, "stavefile.go"), []byte(`//go:build stave
 // +build stave
 
 package main
@@ -1825,7 +1824,7 @@ func TestNamespace(t *testing.T) {
 	stdout := &bytes.Buffer{}
 	inv := Invocation{
 		Dir:    "./testdata/namespaces",
-		Stderr: ioutil.Discard,
+		Stderr: io.Discard,
 		Stdout: stdout,
 		Args:   []string{"ns:error"},
 	}
@@ -1843,7 +1842,7 @@ func TestNamespaceDefault(t *testing.T) {
 	stdout := &bytes.Buffer{}
 	inv := Invocation{
 		Dir:    "./testdata/namespaces",
-		Stderr: ioutil.Discard,
+		Stderr: io.Discard,
 		Stdout: stdout,
 	}
 	code := Invoke(inv)
@@ -1864,7 +1863,7 @@ func TestWrongDependency(t *testing.T) {
 	inv := Invocation{
 		Dir:    "./testdata/wrong_dep",
 		Stderr: stderr,
-		Stdout: ioutil.Discard,
+		Stdout: io.Discard,
 	}
 	code := Invoke(inv)
 	if code != 1 {

--- a/stave/template.go
+++ b/stave/template.go
@@ -12,7 +12,7 @@ import (
 	"context"
 	_flag "flag"
 	_fmt "fmt"
-	_ioutil "io/ioutil"
+	_io "io"
 	_log "log"
 	"os"
 	"os/signal"
@@ -354,7 +354,7 @@ Options:
 
 	_log.SetFlags(0)
 	if !args.Verbose {
-		_log.SetOutput(_ioutil.Discard)
+		_log.SetOutput(_io.Discard)
 	}
 	logger := _log.New(os.Stderr, "", 0)
 	if args.List {

--- a/stave/testdata/setdir/setdir.go
+++ b/stave/testdata/setdir/setdir.go
@@ -5,18 +5,18 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 )
 
 func TestCurrentDir() error {
-	files, err := ioutil.ReadDir(".")
+	entries, err := os.ReadDir(".")
 	if err != nil {
 		return err
 	}
 	var out []string
-	for _, f := range files {
-		out = append(out, f.Name())
+	for _, entry := range entries {
+		out = append(out, entry.Name())
 	}
 
 	fmt.Println(strings.Join(out, ", "))

--- a/stave/testdata/setworkdir/stavefile.go
+++ b/stave/testdata/setworkdir/stavefile.go
@@ -5,18 +5,18 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 )
 
 func TestWorkingDir() error {
-	files, err := ioutil.ReadDir(".")
+	entries, err := os.ReadDir(".")
 	if err != nil {
 		return err
 	}
 	var out []string
-	for _, f := range files {
-		out = append(out, f.Name())
+	for _, entry := range entries {
+		out = append(out, entry.Name())
 	}
 
 	fmt.Println(strings.Join(out, ", "))


### PR DESCRIPTION
## Overview

Modernize the codebase by replacing the deprecated `io/ioutil` package with the recommended `io` and `os` package equivalents. The `io/ioutil` package was deprecated in Go 1.16.

## Changes

### API Migration

Replaced all usages of `io/ioutil` with modern equivalents:

| Deprecated | Replacement |
|------------|-------------|
| `ioutil.Discard` | `io.Discard` |
| `ioutil.TempDir` | `os.MkdirTemp` |
| `ioutil.TempFile` | `os.CreateTemp` |
| `ioutil.ReadFile` | `os.ReadFile` |
| `ioutil.WriteFile` | `os.WriteFile` |
| `ioutil.ReadDir` | `os.ReadDir` |

## Files Changed

- `internal/run.go` - Logger discard
- `parse/parse.go` - Logger discard
- `stave/main.go` - Logger discard, directory reading
- `stave/template.go` - Generated code template
- `stave/main_test.go` - Temp dirs/files, file I/O
- `install_test.go` - Temp directory creation
- `sh/helpers_test.go` - Temp dirs, file I/O
- `stave/testdata/setdir/setdir.go` - Directory reading
- `stave/testdata/setworkdir/stavefile.go` - Directory reading

## Testing

- All existing tests pass
- No behavioral changes, purely API modernization

## Checklist

- [x] All tests passing
- [x] Code compiles cleanly
- [x] No `io/ioutil` imports remain
