### PR TITLE
fix(ci): correct package-name from 'staff' to 'stave'

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -3,7 +3,7 @@
     "packages": {
         ".": {
             "release-type": "go",
-            "package-name": "staff",
+            "package-name": "stave",
             "bump-minor-pre-major": true,
             "bump-patch-for-minor-pre-major": true,
             "changelog-sections": [


### PR DESCRIPTION
Fixes the release-please configuration which had the old project name 'staff' instead of 'stave'.

This was causing PR #10 to use incorrect naming in the release title, branch, and changelog.