### PR TITLE
fix: improve display of default targets in `-l`/`--list`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.3] - 2026-01-03
+
+### Changed
+
+- Improvements to display of default targets in `-l`/`--list` functionality.
+
 ## [0.8.2] - 2026-01-03
 
 ### Changed
@@ -307,7 +313,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Parallelized tests where possible, including locking mechanism to prevent parallel tests in same `testdata/(xyz/)` subdir.
 
-[unreleased]: https://github.com/yaklabco/stave/compare/v0.8.2...HEAD
+[unreleased]: https://github.com/yaklabco/stave/compare/v0.8.3...HEAD
+[0.8.3]: https://github.com/yaklabco/stave/compare/v0.8.2...v0.8.3
 [0.8.2]: https://github.com/yaklabco/stave/compare/v0.8.1...v0.8.2
 [0.8.1]: https://github.com/yaklabco/stave/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/yaklabco/stave/compare/v0.7.0...v0.8.0

--- a/stavefile.go
+++ b/stavefile.go
@@ -249,6 +249,7 @@ func (Setup) Hooks() error {
 
 type Lint st.Namespace
 
+// Default equivalent to lint:all
 func (Lint) Default() error {
 	st.Deps(Lint.All)
 
@@ -433,6 +434,7 @@ func (Prep) BuildCacheDir() error {
 
 type Test st.Namespace
 
+// Default equivalent to test:all
 func (Test) Default() error {
 	st.Deps(Test.All)
 


### PR DESCRIPTION
Changes to display of default targets in `-l`/`--list` functionality:

- Default targets will always be displayed first in their group.
- For default non-namespaced target, target name will be displayed in parentheses in usage string (since it is, effectively, optional).
- For namespaced default targets, the namespace will be omitted from the usage string altogether. (It could be shown in parentheses, as above, but this seems like it would create more "visual clutter" than its worth.)

